### PR TITLE
Replace randomising methods with PHP 8.2 methods

### DIFF
--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -10,6 +10,7 @@ namespace Rovota\Core\Support;
 
 use ArrayAccess;
 use Closure;
+$randomizer = new Random\Randomizer();
 
 final class Arr
 {
@@ -374,10 +375,10 @@ final class Arr
 		$requested = $items === 0 ? 1 : (($items > $count) ? $count : $items);
 
 		if ($requested === 1) {
-			return $array[array_rand($array)];
+			return $array[$randomizer->pickArrayKeys($array)];
 		}
 
-		$keys = array_rand($array, $requested);
+		$keys = $randomizer->pickArrayKeys($array, $requested);
 		$result = [];
 
 		foreach ($keys as $key) {

--- a/src/Support/Text.php
+++ b/src/Support/Text.php
@@ -11,6 +11,7 @@ namespace Rovota\Core\Support;
 use Rovota\Core\Convert\ConversionManager;
 use Rovota\Core\Localization\LocalizationManager;
 use Throwable;
+$randomizer = new Random\Randomizer();
 
 final class Text
 {
@@ -420,7 +421,7 @@ final class Text
 			if (strlen($word) < 4) {
 				$string .= $word.' ';
 			} else {
-				$string .= sprintf('%s%s%s ', $word[0], str_shuffle(substr($word, 1, -1)), $word[strlen($word) - 1]);
+				$string .= sprintf('%s%s%s ', $word[0], $randomizer->shuffleBytes(substr($word, 1, -1)), $word[strlen($word) - 1]);
 			}
 		}
 
@@ -429,7 +430,7 @@ final class Text
 
 	public static function shuffle(string $string): string
 	{
-		return str_shuffle($string);
+		return $randomizer->shuffleBytes($string);
 	}
 
 	public static function simplify(string $string): string


### PR DESCRIPTION
Contributes to #1 

This hasn't been tested properly but follows https://php.watch/versions/8.2/ext-random as the original issue mentioned and the methods practically do the same as the old methods when comparing.

str_shuffle() replaced with shuffleBytes()
array_rand() replaced with pickArrayKeys()

The initialization of the randomiser has been added to the top of the file, but there's likely a prettier way of doing that, so do feel free to rectify as see appropriate. 